### PR TITLE
Handle file names with leading digits

### DIFF
--- a/src/Svg2Elm/Generator.elm
+++ b/src/Svg2Elm/Generator.elm
@@ -65,7 +65,9 @@ compileFunction : String -> String -> Result String String
 compileFunction name code =
     let
         fnName =
-            toCamelCaseLower name
+            name
+                |> toCamelCaseLower
+                |> prefixDigitLeadingNames
 
         fixedCode =
             case Regex.fromString "([\\s\\S]*)<svg" of
@@ -78,3 +80,17 @@ compileFunction name code =
     parseToNode fixedCode
         |> Result.map
             (compileNode True >> (++) (fnName ++ " : List (Attribute msg) -> Svg.Svg msg\n" ++ fnName ++ " attrs = "))
+
+
+prefixDigitLeadingNames : String -> String
+prefixDigitLeadingNames name =
+    case String.uncons name of
+        Just ( first, rest ) ->
+            if Char.isDigit first then
+                "n" ++ name
+
+            else
+                name
+
+        Nothing ->
+            name


### PR DESCRIPTION
When generating icon functions, `svg2elm` camelCases the file name to generate valid Elm function names. However, filenames might start with number digits but Elm identifiers cannot. 

This PR makes sure to generate valid Elm identifiers even if the file name starts with a number by prefixing them with the letter `n`.