### PR TITLE
Improve generated syntax

### DIFF
--- a/src/Svg2Elm/Generator.elm
+++ b/src/Svg2Elm/Generator.elm
@@ -65,7 +65,9 @@ compileFunction : String -> String -> Result String String
 compileFunction name code =
     let
         fnName =
-            toCamelCaseLower name
+            name
+                |> toCamelCaseLower
+                |> prefixDigitLeadingNames
 
         fixedCode =
             case Regex.fromString "([\\s\\S]*)<svg" of
@@ -78,3 +80,17 @@ compileFunction name code =
     parseToNode fixedCode
         |> Result.map
             (compileNode True >> (++) (fnName ++ " : List (Attribute msg) -> Svg.Svg msg\n" ++ fnName ++ " attrs = "))
+
+
+prefixDigitLeadingNames : String -> String
+prefixDigitLeadingNames name =
+    case String.uncons name of
+        Just ( first, rest ) ->
+            if Char.isDigit first then
+                "n" ++ name
+
+            else
+                name
+
+        Nothing ->
+            name

--- a/src/svg2elm.ts
+++ b/src/svg2elm.ts
@@ -64,5 +64,5 @@ export async function generateModule(
 
     const header = generateModuleHeader(moduleName);
 
-    return `${header}\n\n${functions.join("\n\n")}`;
+    return `${header}\n\n${functions.join("\n\n\n")}\n`;
 }


### PR DESCRIPTION
I tried to generate elm icon modules out of the entire FontAwesome 6 distribution and found a couple of syntactic errors in the generated output. This PR addresses all of them:

- When generating a function for a file name that starts with a number, prefix the name with `n` to generate a valid Elm identifier.
- Handle comments between SVG nodes.
- `elm-format` compliant (addresses #9):
  - No redundant parenthesis 
  - Function expression in an indented new line
  - Surround non-empty list elements with spaces  
  - Surround comments with spaces and trim content
  - Two empty lines between declarations
  - End file with a newline
